### PR TITLE
Defer engine binding using a config action

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use these as base classes for declarative model definitions, e.g.::
         
     
 You can then bind these to the `sqlalchemy.url` in your paster `.ini` config by
-importing your model and then including this package, e.g.:
+importing your model and this package, e.g.:
 
     # for example in yourapp.__init__.py
     import mymodel
@@ -28,13 +28,6 @@ importing your model and then including this package, e.g.:
         config.include('pyramid_basemodel')
         config.include('pyramid_tm')
         return config.make_wsgi_app()
-    
-Alternatively, if you package your models as a Pyramid include, as for example
-[pyramid_simpleauth][] does, the trick is to include your package before you
-include this package, e.g.:
-
-    config.include('pyramid_simpleauth') # imports the simple auth model classes
-    config.include('pyramid_basemodel')
 
 Or if this is all too much voodoo, you can just use the `bind_engine` function::
 

--- a/src/pyramid_basemodel/__init__.py
+++ b/src/pyramid_basemodel/__init__.py
@@ -318,15 +318,19 @@ def includeme(config):
       Calls ``bind_engine`` with the configured ``engine``::
       
           >>> includeme(mock_config)
-          >>> pyramid_basemodel.bind_engine.assert_called_with('engine', 
-          ...         should_create=False, should_drop=False)
-      
+          >>>
+          >>> mock_config.action.assert_called_with(None,
+          ...         pyramid_basemodel.bind_engine,
+          ...         ('engine',),
+          ...         {'should_create': False, 'should_drop': False})
+
       Unless told not to::
 
           >>> pyramid_basemodel.bind_engine = Mock()
+          >>> mock_config = Mock()
           >>> mock_config.registry.settings = {'basemodel.should_bind_engine': False}
           >>> includeme(mock_config)
-          >>> pyramid_basemodel.bind_engine.called
+          >>> mock_config.action.called
           False
 
       Teardown::
@@ -348,4 +352,6 @@ def includeme(config):
     should_drop = asbool(settings.get('basemodel.should_drop_all', False))
     if should_bind:
         engine = engine_from_config(settings, 'sqlalchemy.', **engine_kwargs)
-        bind_engine(engine, should_create=should_create, should_drop=should_drop)
+        config.action(None, bind_engine, (engine,), {
+            'should_create': should_create,
+            'should_drop': should_drop})


### PR DESCRIPTION
This means that it's no longer necessary to ensure that all models
are imported before including pyramid_basemodel. Whenever the next
commit of the `Configurator` happens all defined models will be
bound.

Close #6